### PR TITLE
Update live analysis and implement AI trading monitor

### DIFF
--- a/src/app/share/page.tsx
+++ b/src/app/share/page.tsx
@@ -352,6 +352,11 @@ export default function SharePage() {
 
   // AI Trade Detection Functions
   const runTradeDetection = useCallback(async () => {
+    // Guard: If monitoring is active, do not detect new trades
+    if (isMonitoringActiveTrade) {
+      setTradeDetectorStatus('Trade monitoring active - detection paused');
+      return;
+    }
     setTradeDetectorStatus('Analyzing...');
     const frame = captureFrame();
     if (!frame) {
@@ -364,6 +369,9 @@ export default function SharePage() {
         setLastTradeDetectionTime(new Date());
 
         if (result.tradeOpportunity.opportunityFound && !isMonitoringActiveTrade) {
+            // Stop trade detection before any state changes
+            stopTradeDetection();
+            
             const opportunity = {
                 ...result.tradeOpportunity,
                 timestamp: new Date(),
@@ -435,8 +443,7 @@ export default function SharePage() {
             
             setActiveTrade(activeTradeData);
             
-            // Stop trade detection and start monitoring
-            stopTradeDetection();
+            // Start monitoring after detection is stopped
             startTradeMonitoring();
             
         } else if (isMonitoringActiveTrade) {
@@ -460,7 +467,7 @@ export default function SharePage() {
             variant: 'destructive',
         });
     }
-  }, [captureFrame, previousAnalysis, scanMode, toast, tradeDetectionInterval]);
+  }, [captureFrame, previousAnalysis, scanMode, toast, tradeDetectionInterval, isMonitoringActiveTrade, stopTradeDetection, startTradeMonitoring]);
 
   const startTradeDetection = useCallback(() => {
     setIsTradeDetecting(true);


### PR DESCRIPTION
Prevent AI Trade Detector from detecting new trades while an active trade is being monitored.

The previous implementation allowed the trade detection interval to continue running or re-trigger, leading to new trade alerts even when the system was supposed to be focused on monitoring an existing trade. This fix ensures a single, focused trade experience by adding a guard to the detection function and ensuring the detection interval is cleared when monitoring starts.

---

[Open in Web](https://cursor.com/agents?id=bc-7b8f3d55-763f-4700-a618-b92200665900) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7b8f3d55-763f-4700-a618-b92200665900) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)