### PR TITLE
Update live analysis and implement AI trading monitor

### DIFF
--- a/src/app/share/page.tsx
+++ b/src/app/share/page.tsx
@@ -460,6 +460,18 @@ ${result.tradeUpdate.takeProfitProgress.map(tp => `- ${tp.target}: ${tp.progress
     tradeMonitoringIntervalRef.current = setInterval(runTradeMonitoring, tradeUpdateInterval * 1000);
   }, [tradeUpdateInterval, toast, activeTrade]);
 
+  const stopTradeMonitoring = useCallback(() => {
+    setIsMonitoringActiveTrade(false);
+    setTradeMonitoringStatus('Idle');
+    setActiveTrade(null);
+    setTradeUpdates([]);
+    if (tradeMonitoringIntervalRef.current) {
+        clearInterval(tradeMonitoringIntervalRef.current);
+        tradeMonitoringIntervalRef.current = null;
+    }
+    toast({ title: "Trade Monitoring Stopped" });
+  }, [toast]);
+
   // AI Trade Detection Functions
   const runTradeDetection = useCallback(async () => {
     // Guard: If monitoring is active, do not detect new trades


### PR DESCRIPTION
Fixes `ReferenceError` in `SharePage` by reordering function definitions.

The `ReferenceError` occurred because several `useCallback` functions (`stopTradeDetection`, `runTradeMonitoring`, `startTradeMonitoring`, `stopTradeMonitoring`) were being referenced before their initialization within the React component. This PR reorders their definitions to ensure they are available when called.

---

[Open in Web](https://cursor.com/agents?id=bc-7b8f3d55-763f-4700-a618-b92200665900) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7b8f3d55-763f-4700-a618-b92200665900) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)